### PR TITLE
Adding the ability to specify a path using a regular expression

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -155,7 +155,7 @@ For using REST-assured from non-ruby environments.
   Example:
 
 ```
-    $ curl -d 'fullpath=/api/something&content=awesome&response_headers%5BContent-Type%5D=text%2Fhtml' http://localhost:4578/doubles
+    $ curl -d 'fullpath=%2Fapi%2Fsomething%5C%3Fparam%3D.*&content=awesome&response_headers%5BContent-Type%5D=text%2Fhtml' http://localhost:4578/doubles
     {"double":{"active":true,"content":"awesome","description":null,"fullpath":"/api/something","id":1,"response_headers":{"Content-Type":"text/html"},"status":200,"verb":"GET"}}
 
     $ curl http://localhost:4578/api/something
@@ -163,10 +163,10 @@ For using REST-assured from non-ruby environments.
 ```
   Example using a regular expression for the path:
   ```
-      $ curl -d 'fullpath=/api/something&content=awesome&response_headers%5BContent-Type%5D=text%2Fhtml' http://localhost:4578/doubles
-      {"double":{"active":true,"content":"awesome","description":null,"pathpattern":"/api/something","id":1,"response_headers":{"Content-Type":"text/html"},"status":200,"verb":"GET"}}
+      $ curl -d 'pathpattern=/api/something\?param=.*&content=awesome&response_headers%5BContent-Type%5D=text%2Fhtml' http://localhost:4578/doubles
+      {"double":{"active":true,"content":"awesome","description":null,"pathpattern":"/api/something\?param=.*","id":1,"response_headers":{"Content-Type":"text/html"},"status":200,"verb":"GET"}}
 
-      $ curl http://localhost:4578/api/something
+      $ curl http://localhost:4578/api/something?param=foo
       awesome
   ```
 

--- a/README.markdown
+++ b/README.markdown
@@ -89,7 +89,17 @@ Create double:
 RestAssured::Double.create(fullpath: '/products', content: 'this is content')
 ```
 
-Now GET `http://localhost:4578/products` will be returning `this is content`.
+Alternatively using a regular expression for the path
+
+```ruby
+RestAssured::Double.create(pathpattern: /products\/[a-z]{10}\/?param=.*/, content: 'this is more content')
+```
+
+Now GET `http://localhost:4578/products` will be returning `this is content` and a GET to
+`http://localhost:4578/products/coolprod22?param=foo` will be returning `this is more content`.
+
+The pathpattern parameter must be a ruby Regexp object or a string containing a valid regular expression.
+Don't forget you will need to escape thing this slashes and question marks in the pattern.
 
 You can also verify what requests happen on a double (spy on it). Say this is a Given part of a test:
 
@@ -152,8 +162,18 @@ For using REST-assured from non-ruby environments.
     $ curl http://localhost:4578/api/something
     awesome
 ```
+  Example using a regular expression for the path:
+  ```
+      $ curl -d 'fullpath=/api/something&content=awesome&response_headers%5BContent-Type%5D=text%2Fhtml' http://localhost:4578/doubles
+      {"double":{"active":true,"content":"awesome","description":null,"fullpath":"/api/something","id":1,"response_headers":{"Content-Type":"text/html"},"status":200,"verb":"GET"}}
 
-  If there is more than one double for the same fullpath and verb, the last created one gets served. In UI you can manually control which double is 'active' (gets served).
+      $ curl http://localhost:4578/api/something
+      awesome
+  ```
+
+  If there is more than one double for the same fullpath and verb, the last created one gets served.
+  Doubles with `fullpath`'s are served in preference to `pathpattern`'s.
+  In UI you can manually control which double is 'active' (gets served).
 
 #### Get double state
 
@@ -166,6 +186,7 @@ For using REST-assured from non-ruby environments.
         "double": {
             "verb": "GET",
             "fullpath": "/api/something",
+            "pathpattern" : null,
             "response_headers": {
                 "Content-Type": "text/html"
             },

--- a/README.markdown
+++ b/README.markdown
@@ -99,7 +99,6 @@ Now GET `http://localhost:4578/products` will be returning `this is content` and
 `http://localhost:4578/products/coolprod22?param=foo` will be returning `this is more content`.
 
 The pathpattern parameter must be a ruby Regexp object or a string containing a valid regular expression.
-Don't forget you will need to escape thing this slashes and question marks in the pattern.
 
 You can also verify what requests happen on a double (spy on it). Say this is a Given part of a test:
 
@@ -165,7 +164,7 @@ For using REST-assured from non-ruby environments.
   Example using a regular expression for the path:
   ```
       $ curl -d 'fullpath=/api/something&content=awesome&response_headers%5BContent-Type%5D=text%2Fhtml' http://localhost:4578/doubles
-      {"double":{"active":true,"content":"awesome","description":null,"fullpath":"/api/something","id":1,"response_headers":{"Content-Type":"text/html"},"status":200,"verb":"GET"}}
+      {"double":{"active":true,"content":"awesome","description":null,"pathpattern":"/api/something","id":1,"response_headers":{"Content-Type":"text/html"},"status":200,"verb":"GET"}}
 
       $ curl http://localhost:4578/api/something
       awesome

--- a/db/migrate/20170818001158_add_pathpattern_to_doubles.rb
+++ b/db/migrate/20170818001158_add_pathpattern_to_doubles.rb
@@ -1,0 +1,9 @@
+class AddPathpatternToDoubles < ActiveRecord::Migration
+  def self.up
+    add_column :doubles, :pathpattern, :text
+  end
+
+  def self.down
+    remove_column :doubles, :text
+  end
+end

--- a/features/rest_api/doubles.feature
+++ b/features/rest_api/doubles.feature
@@ -18,6 +18,15 @@ Feature: use doubles via api
       | /api/file          |              | HEAD   | HEAD        |        | 200           | 5     | 5            |
       | /api/file          |              | PATCH  | PATCH       |        | 200           | 6     | 6            |
 
+  Scenario Outline: create a double with a url pattern
+    When I create a double with "<pathpattern>" as pathpattern, "<content>" as response content, "<verb>" as request verb, status as "<status>" and delay as "<delay>"
+    Then there should be 1 double with "<pathpattern>" as pathpattern, "<content>" as response content, "<result_verb>" as request verb, status as "<result_status>" and delay as "<result_delay>"
+    Examples:
+      | pathpattern         | content | verb   | result_verb | status | result_status | delay | result_delay |
+      | ^\/api\/.*$         | created | POST   | POST        | 200    | 200           |       | 0            |
+      | ^.*\/\?nocache=\d+$ | changed | PUT    | PUT         | 201    | 201           | 0     | 0            |
+      | ^[a-zA-Z]\/123$     | removed | DELETE | DELETE      | 300    | 300           | 1     | 1            |
+
   Scenario: view created double details
     When I create a double
     Then I should be able to get json representation of that double from response
@@ -36,6 +45,17 @@ Feature: use doubles via api
       | /other/api         |              | GET    | 303    |
       | /patch/api         |              | PATCH  | 200    |
 
+  Scenario Outline: request a path that matches double a path pattern
+    Given there is double with "<pathpattern>" as pathpattern, "<content>" as response content, "<verb>" as request verb and "<status>" as status
+    When I "<verb>" "<fullpath>"
+    Then I should get "<status>" as response status and "<content>" in response content
+
+    Examples:
+      | pathpattern                   | fullpath            | content      | verb | status |
+      | ^.*$                          | /api/something      | created      | POST | 200    |
+      | ^/api/.*$                     | /api/sss            | changed      | PUT  | 201    |
+      | ^\/api\/some\?a=\d&b=[a-z]{2}$ | /api/some?a=3&b=dd | more content | GET  | 203    |
+
   # current rule: last added double gets picked
   Scenario Outline: request fullpath that matches multiple doubles
     Given there is double with "<fullpath>" as fullpath and "<content>" as response content
@@ -47,6 +67,30 @@ Feature: use doubles via api
       | fullpath           | content      | content2        |
       | /api/something     | test content | another content |
       | /api/some?a=3&b=dd | more content | some text       |
+
+  # current rule: full path matches over pattern
+  Scenario Outline: request fullpath that matches the full path of a double and a url pattern of another double
+    Given there is double with "<fullpath>" as fullpath and "<content>" as response content
+    Given there is double with "<pathpattern>" as pathpattern and "<content2>" as response content
+    When I "GET" "<fullpath>"
+    Then I should get "<content>" in response content
+
+    Examples:
+      | fullpath           | content      | pathpattern                  | content2     |
+      | /api/something     | test content | ^/api/.*$                    | more content |
+      | /api/some?a=3&b=dd | test content | ^\/api\/some?a=\d+&b=d[a-z]$ | more content |
+
+  # current rule: last added double gets picked
+  Scenario Outline: request full path that matches more than one path pattern
+    Given there is double with "<pathpattern>" as pathpattern and "<content>" as response content
+    Given there is double with "<pathpattern2>" as pathpattern and "<content2>" as response content
+    When I "GET" "<fullpath>"
+    Then I should get "<content2>" in response content
+
+    Examples:
+      | fullpath             | pathpattern                   | content      | pathpattern2                  | content2     |
+      | /api/sam             | ^.*$                          | test content | ^\/api\/.*$                   | more content |
+      | /api/some?a=123&b=dd | ^\/api\/some\?a=\d+&b=d[a-z]$ | test content | ^\/api\/some\?a=\d+&b=d[a-z]$ | more content |
 
   Scenario: request fullpath that does not match any double
     Given there are no doubles

--- a/features/ruby_api/create_double.feature
+++ b/features/ruby_api/create_double.feature
@@ -20,6 +20,22 @@ Feature: create double
     last_response.should be_ok
     """
 
+  Scenario: use a path pattern
+    When I create a double:
+    """
+    @double = RestAssured::Double.create(:pathpattern => /^\/some\/api\?nocache=\d+$/)
+    """
+    Then the following should be true:
+    """
+    @double.verb.should             == 'GET'
+    @double.response_headers.should == {}
+    @double.status.should           == 200
+    @double.content.should          == nil
+
+    get '/some/api?nocache=1234'
+    last_response.should be_ok
+    """
+
   Scenario: specify response headers
     When I create a double:
     """

--- a/features/step_definitions/doubles_steps.rb
+++ b/features/step_definitions/doubles_steps.rb
@@ -100,7 +100,6 @@ Given /^the following doubles exist:$/ do |doubles|
 end
 
 Then /^I should see existing doubles:$/ do |doubles|
-  save_and_open_page
   doubles.hashes.each do |row|
     page.should have_content(row[:fullpath]) unless row[:fullpath].blank?
     page.should have_content(row[:pathpattern]) unless row[:pathpattern].blank?

--- a/features/web_ui/doubles.feature
+++ b/features/web_ui/doubles.feature
@@ -6,28 +6,42 @@ Feature: manage doubles via ui
 
   Scenario: view existing doubles
     Given the following doubles exist:
-      | fullpath  | description  | content      | verb | delay |
-      | /url1/aaa | twitter      | test content | GET  | 0     |
-      | /url2/bbb | geo location | more content | POST | 1     |
-      | /u/b?c=1  | wikipedia    | article      | PUT  | 2     |
+      | fullpath  | pathpattern             | description  | content         | verb | delay |
+      | /url1/aaa |                         | twitter      | test content    | GET  | 0     |
+      | /url2/bbb |                         | geo location | more content    | POST | 1     |
+      | /u/b?c=1  |                         | wikipedia    | article         | PUT  | 2     |
+      |           | ^/api/foo\?nocache=123$ | pattern      | pattern content | GET  | 0     |
     When I visit "doubles" page
     Then I should see existing doubles:
-      | fullpath  | description  | verb | delay |
-      | /url1/aaa | twitter      | GET  | 0     |
-      | /url2/bbb | geo location | POST | 1     |
-      | /u/b?c=1  | wikipedia    | PUT  | 2     |
+      | fullpath  | pathpattern             | description  | verb | delay |
+      | /url1/aaa |                         | twitter      | GET  | 0     |
+      | /url2/bbb |                         | geo location | POST | 1     |
+      | /u/b?c=1  |                         | wikipedia    | PUT  | 2     |
+      |           | ^/api/foo\?nocache=123$ | pattern      | GET  | 0     |
 
   Scenario: add new double
     Given I am on "doubles" page
     When I choose to create a double
     And I enter double details:
-      | fullpath      | description | content      | verb | status | delay |
-      | /url2/bb?a=b5 | google api  | test content | POST | 200    | 1     |
+      | fullpath      | pathpattern | description | content      | verb | status | delay |
+      | /url2/bb?a=b5 |             | google api  | test content | POST | 200    | 1     |
     And I save it
     Then I should see "Double created"
     And I should see existing doubles:
       | fullpath      | description | verb | status | delay |
       | /url2/bb?a=b5 | google api  | POST | 200    | 1     |
+
+  Scenario: add a new double with a path pattern
+    Given I am on "doubles" page
+    When I choose to create a double
+    And I enter double details:
+      | fullpath | pathpattern | description | content        | verb | status | delay |
+      |          | ^\/api\/.*$ | pattern api | test content 1 | GET  | 200    | 0     |
+    And I save it
+    Then I should see "Double created"
+    And I should see existing doubles:
+      | pathpattern | description | verb | status | delay |
+      | ^\/api\/.*$ | pattern api | GET  | 200    | 1     |
 
   @javascript
   Scenario: choose active double

--- a/lib/rest-assured/routes/double.rb
+++ b/lib/rest-assured/routes/double.rb
@@ -51,7 +51,7 @@ module RestAssured
           end
         rescue
           d = params['double'] ||
-            params.slice(*%w[fullpath content description verb status response_headers delay])
+            params.slice(*%w[fullpath pathpattern content description verb status response_headers delay])
         end
 
         @double = Models::Double.create(d)

--- a/lib/rest-assured/routes/response.rb
+++ b/lib/rest-assured/routes/response.rb
@@ -3,10 +3,11 @@ module RestAssured
 
     def self.perform(app)
       request = app.request
-      if d = Models::Double.where(:fullpath => request.fullpath, :active => true, :verb => request.request_method).first
+      path = request.fullpath
+      if d = find_matching_double(request.request_method, path)
         return_double app, d
       elsif redirect_url = Models::Redirect.find_redirect_url_for(request.fullpath)
-        if d = Models::Double.where(:fullpath => redirect_url, :active => true, :verb => request.request_method).first
+        if d = find_matching_double(request.request_method, redirect_url)
           return_double app, d
         else
           app.redirect redirect_url
@@ -14,6 +15,12 @@ module RestAssured
       else
         app.status 404
       end
+    end
+
+    def self.find_matching_double(method, fullpath)
+      active_doubles_for_verb = Models::Double.where(:active => true, :verb => method)
+      active_doubles_for_verb.select {|d| !d.fullpath.blank? && d.fullpath == fullpath}.sort_by { |d| d[:id] }.last ||
+          active_doubles_for_verb.select {|d| !d.pathpattern.blank? && Regexp.new(d.pathpattern).match(fullpath)}.sort_by { |d| d[:id] }.last
     end
 
     def self.return_double(app, d)

--- a/lib/rest-assured/routes/response.rb
+++ b/lib/rest-assured/routes/response.rb
@@ -3,10 +3,10 @@ module RestAssured
 
     def self.perform(app)
       request = app.request
-      if d = Models::Double.where(:fullpath => request.fullpath, :active => true, :verb => request.request_method).first
+      if d = find_matching_double(request.request_method, request.fullpath)
         return_double app, d
       elsif redirect_url = Models::Redirect.find_redirect_url_for(request.fullpath)
-        if d = Models::Double.where(:fullpath => redirect_url, :active => true, :verb => request.request_method).first
+        if d = find_matching_double(request.request_method, redirect_url)
           return_double app, d
         else
           app.redirect redirect_url
@@ -18,6 +18,7 @@ module RestAssured
 
     def self.find_matching_double(method, fullpath)
       active_doubles_for_verb = Models::Double.where(:active => true, :verb => method)
+
       active_doubles_for_verb.select {|d| !d.fullpath.blank? && d.fullpath == fullpath}.sort_by { |d| d[:id] }.last ||
           active_doubles_for_verb.select {|d| !d.pathpattern.blank? && Regexp.new(d.pathpattern).match(fullpath)}.sort_by { |d| d[:id] }.last
     end

--- a/lib/rest-assured/version.rb
+++ b/lib/rest-assured/version.rb
@@ -1,3 +1,3 @@
 module RestAssured
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end

--- a/spec/functional/double_routes_spec.rb
+++ b/spec/functional/double_routes_spec.rb
@@ -75,7 +75,7 @@ module RestAssured
         post '/doubles', invalid_params
 
         expect(last_response).to be_ok
-        expect(last_response.body).to match(/Crumps!.*Fullpath can't be blank/)
+        expect(last_response.body).to match(/Crumps!.*Exactly one of fullpath or pathpattern must be present/)
       end
 
       it "renders double edit form" do
@@ -137,7 +137,7 @@ module RestAssured
         post '/doubles.json', test_double.except(:fullpath)
 
         expect(last_response).not_to be_ok
-        expect(last_response.body).to match(/\{"fullpath":\["can't be blank"\]\}/)
+        expect(last_response.body).to match(/[\"Exactly one of fullpath or pathpattern must be present\"]/)
       end
 
       it "deletes double" do
@@ -187,7 +187,7 @@ module RestAssured
         post '/doubles.json', test_double.except(:fullpath).to_json, 'CONTENT_TYPE' => 'Application/json'
 
         expect(last_response).not_to be_ok
-        expect(last_response.body).to match(/\{"fullpath":\["can't be blank"\]\}/)
+        expect(last_response.body).to match("{\"path\":[\"Exactly one of fullpath or pathpattern must be present\"]}")
       end
 
       it 'loads double as AR resource' do

--- a/spec/functional/response_spec.rb
+++ b/spec/functional/response_spec.rb
@@ -11,30 +11,21 @@ module RestAssured
       end
     end
 
-    let(:env) { double(:to_json => 'env').as_null_object }
+    let(:env) {double(:to_json => 'env').as_null_object}
+
     let(:request) {
       double('Request',
-        :request_method => 'GET',
-        :fullpath       => '/api',
-        :env            => env,
-        :body           => double(:read    => 'body').as_null_object,
-        :params         => double(:to_json => 'params')
+             :request_method => 'GET',
+             :fullpath => '/api',
+             :env => env,
+             :body => double(:read => 'body').as_null_object,
+             :params => double(:to_json => 'params')
       )
     }
-    let(:rest_assured_app) { double('App', :request => request).as_null_object }
 
-    context 'when double matches request' do
-      before do
-        @double = Models::Double.create \
-          :fullpath         => '/some/path',
-          :content          => 'content',
-          :response_headers => { 'ACCEPT' => 'text/html' },
-          :status           => 201,
-          :delay          => 0
+    let(:rest_assured_app) {double('App', :request => request).as_null_object}
 
-        allow(request).to receive(:fullpath).and_return(@double.fullpath)
-      end
-
+    shared_examples "double_matches" do |path|
       it "returns double content" do
         expect(rest_assured_app).to receive(:body).with(@double.content)
 
@@ -55,17 +46,19 @@ module RestAssured
 
       it 'records request' do
         requests = double
-        allow(Models::Double).to receive_message_chain('where.first').and_return(double(:requests => requests, :delay => 0).as_null_object)
+        allow(Models::Double).to receive(:where).and_return(double(:requests => requests, :delay => 0).as_null_object)
 
         expect(requests).to receive(:create!).with(:rack_env => 'env', :body => 'body', :params => 'params')
 
         Response.perform(rest_assured_app)
       end
-    
+
       it "returns double when redirect matches double" do
         fullpath = '/some/other/path'
         allow(request).to receive(:fullpath).and_return(fullpath)
-        allow(Models::Redirect).to receive(:find_redirect_url_for).with(fullpath).and_return('/some/path')
+        allow(Models::Redirect).to receive(:find_redirect_url_for).with(fullpath).and_return(path)
+        puts "PATH"
+        puts path
 
         expect(rest_assured_app).to receive(:body).with(@double.content)
         expect(rest_assured_app).to receive(:status).with(@double.status)
@@ -73,7 +66,39 @@ module RestAssured
 
         Response.perform(rest_assured_app)
       end
+    end
 
+    context 'when double matches request' do
+      path = '/some/path'
+      before do
+        @double = Models::Double.create \
+          :fullpath => path,
+          :content => 'content',
+          :response_headers => {'ACCEPT' => 'text/html'},
+          :status => 201,
+          :delay => 0
+
+        allow(request).to receive(:fullpath).and_return(@double.fullpath)
+      end
+
+      include_examples "double_matches", path
+    end
+
+    context 'when double matches request pattern' do
+      path = '/api?someparam=something'
+
+      before do
+        @double = Models::Double.create \
+          :pathpattern => '\/api\?someparam=.*',
+          :content => 'content',
+          :response_headers => {'ACCEPT' => 'text/html'},
+          :status => 201,
+          :delay => 0
+
+        allow(request).to receive(:fullpath).and_return(path)
+      end
+
+      include_examples "double_matches", path
     end
 
     it "redirects if double not hit but there is redirect that matches request" do
@@ -97,7 +122,7 @@ module RestAssured
     # TODO change to instead exclude anything that does not respond_to?(:to_s)
     it 'excludes "rack.input" and "rack.errors" as they break with "IOError - not opened for reading:" on consequent #to_json (as they are IO and StringIO)' do
       requests = double.as_null_object
-      allow(Models::Double).to receive_message_chain('where.first').and_return(double(:requests => requests, :delay => 0).as_null_object)
+      allow(Models::Double).to  receive(:where).and_return(double(:requests => requests, :delay => 0).as_null_object)
 
       expect(env).to receive(:except).with('rack.input', 'rack.errors', 'rack.logger')
 
@@ -106,7 +131,7 @@ module RestAssured
 
     it 'it sleeps for delay seconds' do
       requests = double.as_null_object
-      allow(Models::Double).to receive_message_chain('where.first').and_return(double(:requests => requests, :delay => 10).as_null_object)
+      allow(Models::Double).to  receive(:where).and_return(double(:requests => requests, :delay => 10).as_null_object)
 
       Response.stub(:sleep)
       expect(Response).to receive(:sleep).with(10)

--- a/spec/models/double_spec.rb
+++ b/spec/models/double_spec.rb
@@ -13,15 +13,39 @@ module RestAssured::Models
       }
     end
 
-    it { is_expected.to validate_presence_of(:fullpath) }
+    let :valid_params_with_pattern do
+      valid_params.except(:fullpath).merge(:pathpattern => /^\/api\/.*\/[a-zA-Z]\?nocache=true/)
+    end
+
     it { is_expected.to validate_inclusion_of(:verb).in_array Double::VERBS }
     it { is_expected.to validate_inclusion_of(:status).in_array Double::STATUSES }
 
     it { is_expected.to have_many(:requests) }
 
+    it 'rejects double with neither fullpath or pathpattern' do
+      d = Double.new valid_params.except(:fullpath)
+      expect(d).to_not be_valid
+    end
+
+    it 'rejects double with both fullpath or pathpattern' do
+      d = Double.new valid_params.merge(valid_params_with_pattern)
+      expect(d).to_not be_valid
+    end
+
     it 'creates double with valid params' do
       d = Double.new valid_params
       expect(d).to be_valid
+    end
+
+    it 'creates double with pathpattern' do
+      d = Double.new valid_params_with_pattern
+      expect(d).to be_valid
+    end
+
+    it 'rejects double with invalid pathpattern regex string' do
+      # Probably a common mistake - not escaping forward slashes
+      d = Double.new valid_params_with_pattern.merge(:pathpattern => '**')
+      expect(d).to_not be_valid
     end
 
     it "defaults verb to GET" do

--- a/views/doubles/_form.haml
+++ b/views/doubles/_form.haml
@@ -1,6 +1,10 @@
 %p
-  %label{:for => 'double_fullpath'} Request fullpath*
+  Specify either a fullpath or a path pattern
+  %label{:for => 'double_fullpath'} Request fullpath
   %input.wide#double_fullpath{:type => 'text', :name => 'double[fullpath]', :value => @double.fullpath}
+
+  %label{:for => 'double_pathpattern'} Request path pattern
+  %input.wide#double_pathpattern{:type => 'text', :name => 'double[pathpattern]', :value => @double.pathpattern}
 
 %p
   %label{:for => 'double_content'} Content

--- a/views/doubles/index.haml
+++ b/views/doubles/index.haml
@@ -4,6 +4,7 @@
   %thead
     %tr
       %th Request fullpath
+      %th Request path pattern
       %th Description
       %th Verb
       %th Status
@@ -11,7 +12,7 @@
       %th Active?
       %th &nbsp;
   %tbody
-    - @doubles.group_by {|f| f.fullpath + f.verb }.each do |group, fs|
+    - @doubles.group_by {|f| (f.fullpath || f.pathpattern) + f.verb }.each do |group, fs|
       - fs.each_with_index do |f, i|
         %tr{:id => "double_row_#{f.id}"}
           - if i == 0
@@ -20,6 +21,7 @@
                 %a{:href => f.fullpath, :target => '_blank'}= f.fullpath
               - else
                 = f.fullpath
+          %td= f.pathpattern
           %td= f.description
           %td= f.verb
           %td= f.status


### PR DESCRIPTION
We have a usecase where we need to match a url containing a query parameter which we do not know the exact value of in advance.  The option to use a regex for the path enables to acheive this neatly and with out changing production code to put some fixed value in the test which is the current solution.